### PR TITLE
Select by item

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,15 @@
 
 pi2:
-	rsync -rv -e'ssh -J remote.moe' ./ pi@smartmanualstationdanfoss.remote.moe:SmartManualStation/src
+	rsync -rv -e'ssh -J remote.moe' ./ pi@smartmanualstationdanfoss2.remote.moe:SmartManualStation/src
 pi2clean:
-	rsync -rv -e 'ssh -J remote.moe' --delete ./ pi@smartmanualstationdanfoss.remote.moe:SmartManualStation/src
+	rsync -rv -e 'ssh -J remote.moe' --delete ./ pi@smartmanualstationdanfoss2.remote.moe:SmartManualStation/src
+
+piremote:
+	rsync -rv -e'ssh -J remote.moe' ./ pi@smartmanualstation2.remote.moe:SmartManualStation/src
+piremoteclean:
+	rsync -rv -e 'ssh -J remote.moe' --delete ./ pi@smartmanualstation2.remote.moe:SmartManualStation/src
+
+pi:
+	rsync -rv  ./ pi@172.20.66.25:SmartManualStation/src
+piclean:
+	rsync -rv  --delete ./ pi@172.20.25:SmartManualStation/src

--- a/src/content_map.yaml
+++ b/src/content_map.yaml
@@ -11,30 +11,30 @@
 #     
 
 1:
-  name : "blue_front_cover"
-  display_name : 'Blue front cover'
-  description : 'Blue front cover for Festo phone.'
-  image_path : 'img/blue_front_cover.jpg'
+  name : "blue_top_cover"
+  display_name : 'Blue top cover'
+  description : 'Blue top cover for Festo phone.'
+  image_path : 'img/blue_top_cover.jpg'
 2:
-  name : "white_front_cover"
-  display_name : 'White front cover'
-  description : 'White front cover for Festo phone.'
-  image_path : 'img/white_front_cover.jpg'
+  name : "white_top_cover"
+  display_name : 'White top cover'
+  description : 'White top cover for Festo phone.'
+  image_path : 'img/white_top_cover.jpg'
 3:
   name : "fuse_1A"
   display_name : 'Fuse 1Amp'
   description : 'Standard fuse rated for 1 ampere.'
   image_path : 'img/fuse_1A.jpg'
 4:
-  name : "blue_back_cover"
-  display_name : 'Blue back cover'
-  description : 'Blue back cover with camera cutout for Festo phone.'
-  image_path : 'img/blue_back_cover.jpg'
+  name : "blue_bottom_cover"
+  display_name : 'Blue bottom cover'
+  description : 'Blue bottom cover with camera cutout for Festo phone.'
+  image_path : 'img/blue_bottom_cover.jpg'
 5:
-  name : "white_back_cover"
-  display_name : 'White back cover'
-  description : 'White back cover with camera cutout for Festo phone.'
-  image_path : 'img/white_back_cover.jpg'
+  name : "white_bottom_cover"
+  display_name : 'White bottom cover'
+  description : 'White bottom cover with camera cutout for Festo phone.'
+  image_path : 'img/white_bottom_cover.jpg'
 6:
   name : "pcb"
   display_name : 'PCB for Festo Phone'

--- a/src/content_map.yaml
+++ b/src/content_map.yaml
@@ -22,7 +22,7 @@
   image_path : 'img/white_top_cover.jpg'
 3:
   name : "fuse_1A"
-  display_name : 'Fuse 1Amp'
+  display_name : 'Fuse 1 Amp'
   description : 'Standard fuse rated for 1 ampere.'
   image_path : 'img/fuse_1A.jpg'
 4:

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-#!/usr/var/Python3
+#!/usr/bin/python3
 
 import argparse
 import pick_by_light

--- a/src/pick_by_light.py
+++ b/src/pick_by_light.py
@@ -84,12 +84,14 @@ class PickByLight:
 
         Returns:
             bool: success
+            int: port number selected. returns -1 if not successful
         """
         for port_number, content in self._content_map.items():
             if content.get('name', None) == name:
-                return self.select_port(port_number, amount, instructions)
+                success = self.select_port(port_number, amount, instructions)
+                return success, port_number
         else:
-            return False
+            return False, -1
 
 
     def work_finished(self,port_number):
@@ -133,12 +135,14 @@ class PickByLight:
 
         Returns:
             bool: success
+            int: port number selected. returns -1 if not successful
         """
         for port_number, content in self._content_map.items():
             if content.get('name', None) == name:
-                return self.deselect_port(port_number, work_finished)
+                success = self.deselect_port(port_number, work_finished)
+                return success, port_number
         else:
-            return False
+            return False, -1
     
     def deselect_all(self):
         """Deselect and marks all ports as finished

--- a/src/pick_by_light.py
+++ b/src/pick_by_light.py
@@ -73,9 +73,9 @@ class PickByLight:
         return True
     
     def select_content(self, name, amount = 1, instructions = ''):
-        """Select a port from the content within it. Instructions can bu sent
+        """Select a port from the content within it. Instructions can be sent
         along with the selection to instruct the worker on what to do. 
-        The first content that matches the input name will be selected.  
+        The first port with a matching content name will be selected.  
 
         Args:
             name (string): name of the content to be selected
@@ -135,7 +135,7 @@ class PickByLight:
 
         Returns:
             bool: success
-            int: port number selected. returns -1 if not successful
+            int: port number deselected. returns -1 if not successful
         """
         for port_number, content in self._content_map.items():
             if content.get('name', None) == name:

--- a/src/pick_by_light.py
+++ b/src/pick_by_light.py
@@ -71,6 +71,26 @@ class PickByLight:
         self._ports_state[port_number].select_instructions = instructions
         Thread(target=self._signal_thread, args=(port_number,), daemon=True).start()
         return True
+    
+    def select_content(self, name, amount = 1, instructions = ''):
+        """Select a port from the content within it. Instructions can bu sent
+        along with the selection to instruct the worker on what to do. 
+        The first content that matches the input name will be selected.  
+
+        Args:
+            name (string): name of the content to be selected
+            amount (int, optional): Amount to pick. Defaults to 1.
+            instructions (str, optional): Instructions to be displayed for the worker. Defaults to ''.
+
+        Returns:
+            bool: success
+        """
+        for port_number, content in self._content_map.items():
+            if content.get('name', None) == name:
+                return self.select_port(port_number, amount, instructions)
+        else:
+            return False
+
 
     def work_finished(self,port_number):
         """Set flag that the work on this port is now done and submitted.
@@ -89,7 +109,7 @@ class PickByLight:
 
         Args:
             port_number (int): The port number to be deselected
-            work_finished (bool): Is the work done 
+            work_finished (bool): Is the work done or should we just turn off the led.
 
         Returns:
             bool: success
@@ -103,6 +123,22 @@ class PickByLight:
         self._ports_state[port_number].amount_to_pick = 0
         self._ports_state[port_number].select_instructions = ''
         return True
+    
+    def deselect_content(self, name, work_finished=False):
+        """Deselect a port with the giver content name. 
+
+        Args:
+            name (str): The name of the content to be deselected
+            work_finished (bool): Is the work done or should we just turn off the led
+
+        Returns:
+            bool: success
+        """
+        for port_number, content in self._content_map.items():
+            if content.get('name', None) == name:
+                return self.deselect_port(port_number, work_finished)
+        else:
+            return False
     
     def deselect_all(self):
         """Deselect and marks all ports as finished
@@ -302,7 +338,7 @@ class PickByLight:
             self.deselect_port(port_number)
         else:
             logger.info('activity on port: {} cased a warning light to be triggered because the port was not selected')
-            Thread(target=self._warning_signal_thread,daemon=True,args=(port_number,)).start()   
+            Thread(target=self._warning_signal_thread, daemon=True, args=(port_number,)).start()   
     
     def _set_callbacks(self):
         """Sets the callback on all the ports for when an activity occurs"""

--- a/src/station_ua_server.py
+++ b/src/station_ua_server.py
@@ -64,6 +64,7 @@ class StationUAServer:
             content = self._pbl.get_content(port_number)
 
             b_obj.add_variable("ns=2;s=Status.Port_{}.Selected".format(port_number)             ,"Selected"            , bool())
+            b_obj.add_variable("ns=2;s=Status.Port_{}.WorkFinished".format(port_number)         ,"WorkFinished"        , bool())
             b_obj.add_variable("ns=2;s=Status.Port_{}.Instructions".format(port_number)         ,"Instructions"        , "")
             b_obj.add_variable("ns=2;s=Status.Port_{}.Activity".format(port_number)             ,"Activity"            , bool())
             b_obj.add_variable("ns=2;s=Status.Port_{}.ActivityTimestamp".format(port_number)    ,"ActivityTimestamp"   , datetime.fromtimestamp(0))
@@ -78,12 +79,26 @@ class StationUAServer:
             '''
             b_obj = self.Command.add_object('ns=2;s=Command.Port_{}'.format(port_number), "Port_{}".format(port_number))
 
-            b_obj.add_variable("ns=2;s=Command.Port_{}.Selected".format(port_number)             ,"Selected"            , bool()).set_writable()
+            b_obj.add_variable("ns=2;s=Command.Port_{}.Select".format(port_number)               ,"Select"              , bool()).set_writable()
+            b_obj.add_variable("ns=2;s=Command.Port_{}.Deselect".format(port_number)             ,"Deselect"            , bool()).set_writable()
             b_obj.add_variable("ns=2;s=Command.Port_{}.Instructions".format(port_number)         ,"Instructions"        , "").set_writable()
             b_obj.add_variable("ns=2;s=Command.Port_{}.ContentDisplayName".format(port_number)   ,"ContentDisplayName"  , content['display_name']).set_writable()
             b_obj.add_variable("ns=2;s=Command.Port_{}.ContentName".format(port_number)          ,"ContentName"         , content['name']).set_writable()
             b_obj.add_variable("ns=2;s=Command.Port_{}.ContentDescription".format(port_number)   ,"ContentDescription"  , content['description']).set_writable()
             b_obj.add_variable("ns=2;s=Command.Port_{}.ContentImagePath".format(port_number)     ,"ContentImagePath"    , content['image_path']).set_writable()
+        
+        '''
+        Generate some common commands 
+        '''
+        # Make a folder for the commons
+        b_obj = self.Status.add_object('ns=2;s=Command.ByContent', 'ByContent')
+
+        b_obj.add_variable("ns=2;s=Command.ByContent.Select"         ,"Select"          , bool()).set_writable()
+        b_obj.add_variable("ns=2;s=Command.ByContent.Deselect"       ,"Deselect"        , bool()).set_writable()
+        b_obj.add_variable("ns=2;s=Command.ByContent.Name"           ,"Name"      , ""    ).set_writable()
+        b_obj.add_variable("ns=2;s=Command.ByContent.Instructions"   ,"Instructions"    , ""    ).set_writable()
+
+
 
     def _generate_subscriptions(self):
         # Create UA subscriber node for the box. Set self as handler.
@@ -91,9 +106,9 @@ class StationUAServer:
  
         # Subscribe to the Select tag and all the content tags
         for port_number, port in self._pbl.get_ports():
-            a = self.ua_server.get_node("ns=2;s=Status.Port_{}.Selected".format(port_number))
-            sub.subscribe_data_change(a)
-            ac = self.ua_server.get_node("ns=2;s=Command.Port_{}.Selected".format(port_number))
+            ac = self.ua_server.get_node("ns=2;s=Command.Port_{}.Select".format(port_number))
+            sub.subscribe_data_change(ac)
+            ac = self.ua_server.get_node("ns=2;s=Command.Port_{}.Deselect".format(port_number))
             sub.subscribe_data_change(ac)
             b = self.ua_server.get_node("ns=2;s=Command.Port_{}.ContentDisplayName".format(port_number))
             sub.subscribe_data_change(b)
@@ -103,6 +118,14 @@ class StationUAServer:
             sub.subscribe_data_change(d)
             e = self.ua_server.get_node("ns=2;s=Command.Port_{}.ContentImagePath".format(port_number))
             sub.subscribe_data_change(e)
+            a = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")  
+            sub.subscribe_data_change(a)
+            a = self.ua_server.get_node("ns=2;s=Command.ByContent.Deselect")  
+            sub.subscribe_data_change(a)
+            a = self.ua_server.get_node("ns=2;s=Command.ByContent.Name")  
+            sub.subscribe_data_change(a)
+            a = self.ua_server.get_node("ns=2;s=Command.ByContent.Instructions")
+            sub.subscribe_data_change(a)
 
     def _event_notification(self, event):
         logger.warning("Python: New event. No function implemented. {}".format(event))
@@ -129,45 +152,63 @@ class StationUAServer:
         
         logger.debug("New data change event. node:{}, value:{}".format(node, val))
         
-        # Sorry about these two lines of code, but I don't see any nicer way of determining the port number than from 
+        # Sorry about these lines of code, but I don't see any nicer way of determining the port number than from 
         # the identifier string. Then splitting it up to isolate the port number.
         # Example "Status.Port_2.Selected"  is split into ['Status', 'Port_2', 'Selected'] then 'Port_2' is split into 
         # ['Port', '2'] and then the '2' is turned into an intiger.
-        name = str(node.nodeid.Identifier).split(".")
-        port_number = int(name[1].split("_")[1])
-        
-        # Remember if this as a status tag. Special case to auto set the command tag back to false when ever the port
-        # is deselected.
-        isStatus = name[0] == "Status"
-        
-        # using the split name we can assume that the last term is the tag that updated.
-        tag = name[-1] 
-        
-        """ Switch for each possible tag"""
-        # If the status tag "selected" changes to false. Automatically set the command tag back to false as well. 
-        if tag == 'Selected' and isStatus:
-            if val == False:
-                node = self.ua_server.get_node("ns=2;s=Command.Port_{}.Selected".format(port_number))
-                node.set_value(False)
+        path_list = str(node.nodeid.Identifier).split(".")
 
-        # If the command tag "Selected" changes go select that port with the instructions saved in the command tag. 
-        elif tag == 'Selected' and not isStatus:
+        # We can safely assume that the last term is the tag that updated.
+        tag = path_list[-1] 
+        
+        # Figure out the port number
+        port_number = None
+        if 'Port' in path_list[1]:
+            port_number = int(path_list[1].split("_")[-1])        
+    
+        """ Switch for each possible tag"""
+        # If the command tag "Select" changes go select that port with the instructions saved in the command tag. 
+        if tag == 'Select' and port_number:
             if val == True:
                 node = self.ua_server.get_node("ns=2;s=Command.Port_{}.Instructions".format(port_number))
                 instructions = node.get_value()
                 self._pbl.select_port(port_number, instructions=instructions)
-            else:
-                self._pbl.deselect_port(port_number)
+                # Reset the select flag
+                node = self.ua_server.get_node("ns=2;s=Command.Port_{}.Select".format(port_number))
+                node.set_value(False)
+        
+        elif tag == 'Deselect' and port_number:
+            if val == True:
+                self._pbl.deselect_port(port_number, work_finished=True)
+                # Reset the select flag
+                node = self.ua_server.get_node("ns=2;s=Command.Port_{}.Deselect".format(port_number))
+                node.set_value(False)
 
-        elif tag == 'ContentDisplayName':
+        elif tag == 'ContentDisplayName' and port_number:
                 self._pbl.set_content_key(port_number,'display_name', str(val))
-        elif tag == 'ContentName':
+        elif tag == 'ContentName' and port_number:
                 self._pbl.set_content_key(port_number,'name', str(val))
-        elif tag == 'ContentDescription':
+        elif tag == 'ContentDescription' and port_number:
                 self._pbl.set_content_key(port_number,'description', str(val))
-        elif tag == 'ContentImagePath':
+        elif tag == 'ContentImagePath' and port_number:
                 self._pbl.set_content_key(port_number,'image_path', str(val))
     
+        elif tag == 'Select' and 'ByContent' in path_list[1]:
+            if val == True:
+                instructions = self.ua_server.get_node("ns=2;s=Command.ByContent.Instructions").get_value()
+                name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()
+                self._pbl.select_name(name = name, instructions=instructions)
+                # Reset the select flag
+                node = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")
+                node.set_value(False)
+        elif tag == 'Deselect' and 'ByContent' in path_list[1]:
+            if val == True:
+                name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()
+                self._pbl.deselect_content(name = name, work_finished=True)
+                # Reset the select flag
+                node = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")
+                node.set_value(False)
+
 
     def _var_updater(self):
         while True:
@@ -185,6 +226,8 @@ class StationUAServer:
                 state = self._pbl.get_port_state(port_number)         
                 node = self.ua_server.get_node("ns=2;s=Status.Port_{}.Selected".format(port_number))
                 node.set_value(state.selected)
+                node = self.ua_server.get_node("ns=2;s=Status.Port_{}.WorkFinished".format(port_number))
+                node.set_value(state.work_finished)
                 node = self.ua_server.get_node("ns=2;s=Status.Port_{}.Instructions".format(port_number))
                 node.set_value(state.select_instructions)
 

--- a/src/station_ua_server.py
+++ b/src/station_ua_server.py
@@ -91,7 +91,7 @@ class StationUAServer:
         Generate some common commands 
         '''
         # Make a folder for the commons
-        b_obj = self.Status.add_object('ns=2;s=Command.ByContent', 'ByContent')
+        b_obj = self.Command.add_object('ns=2;s=Command.ByContent', 'ByContent')
 
         b_obj.add_variable("ns=2;s=Command.ByContent.Select"         ,"Select"          , bool()).set_writable()
         b_obj.add_variable("ns=2;s=Command.ByContent.Deselect"       ,"Deselect"        , bool()).set_writable()
@@ -197,7 +197,7 @@ class StationUAServer:
             if val == True:
                 instructions = self.ua_server.get_node("ns=2;s=Command.ByContent.Instructions").get_value()
                 name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()
-                self._pbl.select_name(name = name, instructions=instructions)
+                self._pbl.select_content(name = name, instructions=instructions)
                 # Reset the select flag
                 node = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")
                 node.set_value(False)
@@ -206,7 +206,7 @@ class StationUAServer:
                 name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()
                 self._pbl.deselect_content(name = name, work_finished=True)
                 # Reset the select flag
-                node = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")
+                node = self.ua_server.get_node("ns=2;s=Command.ByContent.Deselect")
                 node.set_value(False)
 
 


### PR DESCRIPTION
enables you to select a port by it's content name. if you decide to change the content map the selection process should be exactly the same. This way it is easier than ever to use the smart manual station. The naming of the content also got a cleanup since it was a mix before. Now it all follows a pattern, making the content names easier to remember.

The ua server and festo connect have both been updated to reflect these changes. 