### PR TITLE
Select by content opcua feedback

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 
-pi2:
+pidanfos:
 	rsync -rv -e'ssh -J remote.moe' ./ pi@smartmanualstationdanfoss2.remote.moe:SmartManualStation/src
-pi2clean:
+pidanfosclean:
 	rsync -rv -e 'ssh -J remote.moe' --delete ./ pi@smartmanualstationdanfoss2.remote.moe:SmartManualStation/src
 
 piremote:

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,8 @@ parser = argparse.ArgumentParser(
 parser.add_argument("-v", "--verbose", help="increase output verbosity", action="store_true")
 parser.add_argument("-d", "--dummy", help="run in dummy mode without the actual hardware", action="store_true")
 parser.add_argument("-C", "--content_map", help="path to the content map", type=str)
+parser.add_argument("-f", "--festo_connect", help="enable festo connect", action="store_true")
+parser.add_argument("-i", "--festo_connect_ip", help="ip address for festo connect", type=str)
 
 # If verbose flag set the debugger level accordingly on all improted files 
 # TODO Setting the debug level seems to not work correctly.
@@ -57,10 +59,9 @@ if __name__ == "__main__":
     # Create our gui interface, passing in our pick by light instance.
     GUI = gui.Gui(PBL)
 
-    # Create festo connect object
-    FC = festo_connect.FestoServer(PBL,"192.168.1.68")
-
-
+    if args.festo_connect:
+        # Create festo connect object
+        FC = festo_connect.FestoServer(PBL,args.festo_connect_ip)
 
     try:
         # GUI.run blocks untill it exits

--- a/src/station_ua_server.py
+++ b/src/station_ua_server.py
@@ -95,8 +95,9 @@ class StationUAServer:
 
         b_obj.add_variable("ns=2;s=Command.ByContent.Select"         ,"Select"          , bool()).set_writable()
         b_obj.add_variable("ns=2;s=Command.ByContent.Deselect"       ,"Deselect"        , bool()).set_writable()
-        b_obj.add_variable("ns=2;s=Command.ByContent.Name"           ,"Name"      , ""    ).set_writable()
+        b_obj.add_variable("ns=2;s=Command.ByContent.Name"           ,"Name"            , ""    ).set_writable()
         b_obj.add_variable("ns=2;s=Command.ByContent.Instructions"   ,"Instructions"    , ""    ).set_writable()
+        b_obj.add_variable("ns=2;s=Command.ByContent.Result"         ,"Result"          , -1    ).set_writable()
 
 
 
@@ -197,10 +198,13 @@ class StationUAServer:
             if val == True:
                 instructions = self.ua_server.get_node("ns=2;s=Command.ByContent.Instructions").get_value()
                 name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()
-                self._pbl.select_content(name = name, instructions=instructions)
+                _, selected_port = self._pbl.select_content(name = name, instructions=instructions)
                 # Reset the select flag
                 node = self.ua_server.get_node("ns=2;s=Command.ByContent.Select")
                 node.set_value(False)
+                node = self.ua_server.get_node("ns=2;s=Command.ByContent.Result")
+                node.set_value(selected_port)
+
         elif tag == 'Deselect' and 'ByContent' in path_list[1]:
             if val == True:
                 name = self.ua_server.get_node("ns=2;s=Command.ByContent.Name").get_value()


### PR DESCRIPTION
With this pull request, you can now select by the content name described in the content map. This makes it easier when content changes. Now you don't need to know where the content you want is, you just need to know the name of it. 